### PR TITLE
fix: add machine-id volume mount

### DIFF
--- a/packer/k3d-config.yaml
+++ b/packer/k3d-config.yaml
@@ -19,6 +19,11 @@ options:
           - server:*
   k3d:
     wait: true
+volumes:
+  - volume: /etc/machine-id:/etc/machine-id
+    nodeFilters:
+      - server:0
+      - agent:*
 ports:
   - port: 80:80
     nodeFilters:


### PR DESCRIPTION
This is required for promtail to work.  Noticed when trying to do an upgrade of DUBBD on K3D.